### PR TITLE
Add brand-tone chatbot demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Brand-Tone Chatbot Prompt
+
+This demo shows how to maintain a friendly brand voice when chatting with users. The Buddy-Tech persona from ACME-Shop answers questions concisely and positively, using emoji sparingly.
+
+## Setup
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Create a `.env` file with your `OPENAI_API_KEY`.
+
+## Run
+
+```bash
+python chatbot.py
+```
+
+The demo runs for five user turns and then prints a short summary.

--- a/chatbot.py
+++ b/chatbot.py
@@ -1,0 +1,84 @@
+"""CLI demo for the Buddy-Tech chatbot."""
+from __future__ import annotations
+
+import json
+import os
+from typing import List, Dict
+
+import openai
+from dotenv import load_dotenv
+
+
+class Memory:
+    """Store chat history and handle periodic summarization."""
+
+    def __init__(self, initial: List[Dict[str, str]]) -> None:
+        self.messages: List[Dict[str, str]] = list(initial)
+        self.turns = 0
+        self.summary = ""
+
+    def add(self, role: str, content: str) -> None:
+        """Add a message and summarize every three user turns."""
+        self.messages.append({"role": role, "content": content})
+        if role == "user":
+            self.turns += 1
+            if self.turns % 3 == 0:
+                self._append_summary()
+
+    def _append_summary(self) -> None:
+        """Use OpenAI to summarize the conversation in one sentence."""
+        prompt = self.messages + [
+            {
+                "role": "system",
+                "content": (
+                    "Summarize the conversation above in one concise sentence "
+                    "while keeping ACME-Shop's friendly expert tone."
+                ),
+            }
+        ]
+        resp = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo", temperature=0, messages=prompt
+        )
+        self.summary = resp.choices[0].message["content"].strip()
+        self.messages.append({"role": "system", "content": f"Summary: {self.summary}"})
+
+
+def load_prompts(path: str) -> List[Dict[str, str]]:
+    """Load system and few-shot prompts from a JSON markdown file."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    msgs = [{"role": "system", "content": data["system"]}]
+    for pair in data.get("examples", []):
+        msgs.append({"role": "user", "content": pair["user"]})
+        msgs.append({"role": "assistant", "content": pair["assistant"]})
+    return msgs
+
+
+def ask_openai(messages: List[Dict[str, str]]) -> str:
+    """Send messages to OpenAI and return the assistant reply."""
+    resp = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo", temperature=0, messages=messages
+    )
+    return resp.choices[0].message["content"].strip()
+
+
+def main() -> None:
+    """Run the conversation loop for five user turns."""
+    load_dotenv()
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+
+    messages = load_prompts("prompts.md")
+    memory = Memory(messages)
+
+    for _ in range(5):
+        user_input = input("You: ")
+        memory.add("user", user_input)
+        reply = ask_openai(memory.messages)
+        print(f"Buddy-Tech: {reply}")
+        memory.add("assistant", reply)
+
+    print("\nFinal summary:\n" + memory.summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/prompts.md
+++ b/prompts.md
@@ -1,0 +1,7 @@
+{
+  "system": "You are Buddy-Tech from ACME-Shop, a friendly technology expert. Provide concise answers with a positive tone and sprinkle in the occasional emoji 😊. Avoid negative words, politics, and external links. If a question is off-topic, reply: 'I’m not sure, but I can find that out!'",
+  "examples": [
+    {"user": "How do I track my order?", "assistant": "Sure thing! Head to your account and select 'Order Status' for the latest updates 😊."},
+    {"user": "What's the warranty on your gadgets?", "assistant": "All ACME-Shop gadgets come with a one-year warranty. We’re always here to help with any issues."}
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai
+python-dotenv


### PR DESCRIPTION
## Summary
- add prompts with Buddy-Tech brand instructions and examples
- implement CLI chatbot using OpenAI API with memory summarization
- include minimal requirements and README instructions

## Testing
- `python -m py_compile chatbot.py`

------
https://chatgpt.com/codex/tasks/task_e_684a4865d168832886ef701371146dba